### PR TITLE
Make the 'gif' argument more hilarious.

### DIFF
--- a/app.py
+++ b/app.py
@@ -112,7 +112,7 @@ arguments = [
         ('naming',),
     ),
     (
-        ('Pronounced jif', 'Pronounced gif',),
+        ('Pronounced gif', 'Pronounced gif',),
         ('naming',),
     ),
     (


### PR DESCRIPTION
The debate is already settled when presented as "jif" vs. "gif".
